### PR TITLE
Added possibility to add a fake H bonds 

### DIFF
--- a/hbond_benchmark/hydrogen_bonds.py
+++ b/hbond_benchmark/hydrogen_bonds.py
@@ -27,11 +27,13 @@ def h_bond_dist(mol, conf, donor_idx, donor_h_idx, acceptor_idx, hbond_top_dists
 def get_donor_acceptor_distances(mol, n_conformers=10, hbond_top_dists=(4, 5, 6)):
     donors = [x[0] for x in Lipinski._HDonors(mol)]
     acceptors = [x[0] for x in Lipinski._HAcceptors(mol)]
+    # If molecule does not have any donor and acceptor then we can skip
+    if len(donors) < 1 or len(acceptors) < 1:
+        return donors, acceptors, np.empty(0)
     # isolate donor hydrogens
     mol_with_h = Chem.AddHs(mol)
     donors_hs = [[y.GetIdx() for y in mol_with_h.GetAtoms()[x].GetNeighbors() if
                   y.GetSymbol() == 'H'] for x in donors]
-
     r = Chem.EmbedMultipleConfs(mol_with_h, numConfs=n_conformers, randomSeed=42, maxAttempts=3)
     if r == -1:
         raise(ValueError("Couldn't embed"))

--- a/hbond_benchmark/model.py
+++ b/hbond_benchmark/model.py
@@ -29,6 +29,8 @@ class MolData(LightningDataModule):
             y_idx=None,
             task_type='regression',
             hydrogen_bonds=False,
+            fake=False,
+            fake_proba=0.15,
             hbond_cutoff_dist=2.35,
             hbond_top_dists=(4, 5, 6),
             batch_size=32,
@@ -40,6 +42,8 @@ class MolData(LightningDataModule):
         self.smiles_idx = smiles_idx
         self.y_idx = y_idx
         self.hydrogen_bonds = hydrogen_bonds
+        self.fake_hbonds = fake
+        self.fake_hbonds_proba = fake_proba
         self.hbond_cutoff_dist = hbond_cutoff_dist
         self.hbond_top_dists = hbond_top_dists
         self.batch_size = batch_size
@@ -69,6 +73,8 @@ class MolData(LightningDataModule):
                 smiles_idx=self.smiles_idx,
                 y_idx=self.y_idx,
                 hbonds=self.hydrogen_bonds,
+                fake=self.fake_hbonds,
+                proba=self.fake_hbonds_proba,
                 hbond_cutoff_dist=self.hbond_cutoff_dist,
                 hbond_top_dists=self.hbond_top_dists,
                 name=self.name,

--- a/hbond_benchmark/molecule_net.py
+++ b/hbond_benchmark/molecule_net.py
@@ -424,7 +424,6 @@ def fake_hbonds(mol, edge_indices, edge_attrs, proba):
         atoms = [y.GetIdx() for y in mol.GetAtoms()]
         if len(atoms) >= 2:
             donor_idx, acceptor_idx = np.random.choice(atoms, size=2, replace=False)
-            #print('Adding fake H bond between atoms {} and {}'.format(donor_idx, acceptor_idx))
             e = []
             e.append(e_map['bond_type'].index('HYDROGEN'))
             e.append(e_map['stereo'].index('STEREONONE'))

--- a/hbond_benchmark/train.py
+++ b/hbond_benchmark/train.py
@@ -20,6 +20,8 @@ def parse_args(args):
     parser.add_argument('--y_idx', type=int, nargs='*', default=None)
     parser.add_argument('--task_type', type=str, default='regression')
     parser.add_argument('--hbonds', action='store_true', default=False)
+    parser.add_argument('--fake', action='store_true', default=False)
+    parser.add_argument('--fake_proba', type=float, default=0.15)
     parser.add_argument('--n_runs', type=int, default=1)
     parser.add_argument('--early_stopping', type=int, default=None)
     parser.add_argument('--hbond_cutoff_dist', type=float, default=2.35)


### PR DESCRIPTION
between two random atoms of a molecule and give it a type HYDROGEN. The probability for a molecule to get such a bond is controlled by fake_proba.

Added a shortcut in hydrogen_bonds in case an input molecule does not have both donor and acceptor (in which case we do not need to compute 3D conformations)